### PR TITLE
Adds monitoring tool

### DIFF
--- a/odltools/common/constants.py
+++ b/odltools/common/constants.py
@@ -1,0 +1,28 @@
+# Copyright 2018 Red Hat, Inc. and others. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# constants for odl monitoring
+# color pairs
+DEFAULT_COLOR = 0
+WHITE_ON_BLACK = 1
+WHITE_ON_GREEN = 2
+WHITE_ON_BLUE = 3
+WHITE_ON_YELLOW = 4
+BLACK_ON_YELLOW = 5
+
+LEADER = 'Leader'
+FOLLOWER = 'Follower'
+CANDIDATE = 'Candidate'
+
+MAX_CONTROLLER_NAME_LEN = 21

--- a/odltools/common/odl_client.py
+++ b/odltools/common/odl_client.py
@@ -1,0 +1,46 @@
+# Copyright 2018 Red Hat, Inc. and others. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from requests import sessions
+
+logger = logging.getLogger('common.odl_client')
+
+
+class OpenDaylightRestClient(object):
+
+    def __init__(self, url, username, password, timeout):
+        super(OpenDaylightRestClient, self).__init__()
+        self.url = url
+        self.timeout = timeout
+        self.session = sessions.Session()
+        self.session.auth = (username, password)
+
+    def get(self, urlpath='', data=None):
+        return self.request('get', urlpath, data)
+
+    def put(self, urlpath='', data=None):
+        return self.request('put', urlpath, data)
+
+    def delete(self, urlpath='', data=None):
+        return self.request('delete', urlpath, data)
+
+    def request(self, method, urlpath='', data=None):
+        headers = {'Content-Type': 'application/json'}
+        url = '/'.join([self.url, urlpath])
+        logging.debug(
+            "Sending METHOD (%(method)s) URL (%(url)s) JSON (%(data)s)",
+            {'method': method, 'url': url, 'data': data})
+        return self.session.request(
+            method, url=url, headers=headers, data=data, timeout=self.timeout)

--- a/odltools/monitor/cli.py
+++ b/odltools/monitor/cli.py
@@ -1,9 +1,45 @@
-def haha(args):
-    print("tim, tim, bo-bim, banana-fana, foo-fim, tiiiimmm")
+# Copyright 2018 Red Hat, Inc. and others. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import odltools.monitor.monitor_odl_cluster as monitor
+
+JSON_FORMAT = """
+    {
+        "cluster": {
+            "controllers": [
+                {"ip": "172.17.10.93", "port": "8181"},
+                {"ip": "172.17.10.93", "port": "8181"},
+                {"ip": "172.17.10.93", "port": "8181"}
+            ],
+            "user": "username",
+            "pass": "password",
+            "shards_to_exclude": ["prefix-configuration-shard"]
+        }
+    }
+"""
 
 
 def add_parser(parsers):
-    parser = parsers.add_parser("tim", description="timothy")
-    parser.add_argument("tim",
-                        help="say something funny!")
-    parser.set_defaults(func=haha)
+    parser = parsers.add_parser("monitor",
+                                description="Graphical tool for monitoring "
+                                            "an OpenDaylight cluster")
+    parser.set_defaults(func=monitor.run_monitor)
+    parser.add_argument('-d', '--datastore', default='Config', type=str,
+                        choices=["Config", "Operational"],
+                        help=('polling can be done on "Config" or '
+                              '"Operational" data stores'))
+    parser.add_argument('config_file',
+                        metavar='cluster.json',
+                        help='JSON Cluster configuration file in the '
+                             'following format:\n{}'.format(JSON_FORMAT))

--- a/odltools/monitor/monitor_odl_cluster.py
+++ b/odltools/monitor/monitor_odl_cluster.py
@@ -1,0 +1,311 @@
+# Copyright 2018 Red Hat, Inc. and others. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Cluster Monitor Tool
+
+This tool provides real-time visualization of the cluster member roles for all
+shards in either the config or operational datastore.
+
+A JSON file containing a list of the IP addresses and port numbers of the
+controllers and other information is required.  The file should look like this:
+
+    {
+        "cluster": {
+            "controllers": [
+                {"ip": "172.17.10.93", "port": "8181"},
+                {"ip": "172.17.10.93", "port": "8181"},
+                {"ip": "172.17.10.93", "port": "8181"}
+            ],
+            "user": "username",
+            "pass": "password",
+            "shards_to_exclude": ["prefix-configuration-shard"]
+        }
+    }
+"""
+
+import curses
+import json
+import math
+import os
+import re
+import time
+
+from requests import exceptions
+
+import odltools.common.constants as con
+import odltools.common.odl_client as client
+
+
+class OdlMonitoringException(Exception):
+    pass
+
+
+class OdlClusterCfgException(Exception):
+    pass
+
+
+class CursesWindow(object):
+    def __enter__(self):
+        stdscr = curses.initscr()
+        curses.noecho()
+        curses.cbreak()
+        curses.curs_set(0)  # Invisible
+        stdscr.keypad(True)
+        stdscr.nodelay(True)
+        curses.start_color()
+        curses.init_pair(con.WHITE_ON_BLACK, curses.COLOR_WHITE,
+                         curses.COLOR_BLACK)
+        curses.init_pair(con.WHITE_ON_GREEN, curses.COLOR_WHITE,
+                         curses.COLOR_GREEN)
+        curses.init_pair(con.WHITE_ON_BLUE, curses.COLOR_WHITE,
+                         curses.COLOR_BLUE)
+        curses.init_pair(con.WHITE_ON_YELLOW, curses.COLOR_WHITE,
+                         curses.COLOR_YELLOW)
+        curses.init_pair(con.BLACK_ON_YELLOW, curses.COLOR_BLACK,
+                         curses.COLOR_YELLOW)
+        return stdscr
+
+    def __exit__(self, *args):
+        curses.nocbreak()
+        curses.echo()
+        curses.nl()
+        curses.endwin()
+
+
+def get_cluster_roles(shard_name, controllers, data_store):
+    controller_state = {}
+    for controller in controllers:
+        controller_state[controller["ip"]] = None
+        url_path = ('org.opendaylight.controller:Category'
+                    '=Shards,name={}-shard-{}-{},type=Distributed{}'
+                    'Datastore'.format(controller['name'], shard_name,
+                                       data_store.lower(), data_store))
+        odl_client = controller['client']
+        try:
+            resp = odl_client.request('get', url_path)
+            if resp.status_code != 200:
+                controller_state[controller["ip"]] = ('HTTP ' +
+                                                      str(resp.status_code))
+            else:
+                resp_data = resp.json()
+                try:
+                    controller_state[controller["ip"]] = (resp_data['value'][
+                        'RaftState'])
+                except KeyError:
+                    controller_state[controller["ip"]] = "HTTP Parsing Error"
+
+        except exceptions.ConnectionError:
+            controller_state[controller["ip"]] = 'Connection Error'
+        except exceptions.ReadTimeout:
+            controller_state[controller["ip"]] = 'HTTP Read Timeout'
+        except ValueError:
+            controller_state[controller["ip"]] = 'JSON Error'
+
+    return controller_state
+
+
+def size_and_color(cluster_roles, field_length, ip_addr):
+    status_dict = {
+        'txt': str(cluster_roles[ip_addr]).center(field_length)
+    }
+    # color map
+    role_to_color = {
+        con.LEADER: curses.color_pair(con.WHITE_ON_GREEN),
+        con.FOLLOWER: curses.color_pair(con.WHITE_ON_BLUE),
+        con.CANDIDATE: curses.color_pair(con.BLACK_ON_YELLOW)
+    }
+
+    status_dict['color'] = role_to_color.get(
+        cluster_roles[ip_addr], curses.color_pair(con.DEFAULT_COLOR))
+    return status_dict
+
+
+def handle_window_resize(stdscr, y, x):
+    if curses.is_term_resized(y, x):
+        maxy, maxx = stdscr.getmaxyx()
+        stdscr.clear()
+        curses.resizeterm(y, x)
+        stdscr.refresh()
+    else:
+        maxy = y
+        maxx = x
+    return maxy, maxx
+
+
+def cluster_monitor(stdscr, controllers, username, password, data_store,
+                    excluded_shards=None):
+    shards = set()
+    (maxy, maxx) = stdscr.getmaxyx()
+    controller_len = con.MAX_CONTROLLER_NAME_LEN
+    field_len = 0
+    stdscr.addstr(len(controllers) + 3, 0,
+                  'Polling controllers, please wait...',
+                  curses.color_pair(con.WHITE_ON_BLACK))
+    stdscr.addstr(len(controllers) + 4, 0,
+                  'Press q or use ctrl + c to quit.',
+                  curses.color_pair(con.WHITE_ON_BLACK))
+    stdscr.refresh()
+    # create rest clients for each controller
+    for controller in controllers:
+        url = ("http://{}:{}/jolokia/read".format(controller['ip'],
+                                                  controller['port']))
+        controller['client'] = client.OpenDaylightRestClient(
+            username=username, password=password, url=url, timeout=2)
+
+    key = -1
+    while key != ord('q') and key != ord('Q'):
+        (maxy, maxx) = handle_window_resize(stdscr, maxy, maxx)
+        key = max(key, stdscr.getch())
+
+        # Retrieve controller names and shard names.
+        for controller in controllers:
+            key = max(key, stdscr.getch())
+            if key == ord('q') or key == ord('Q'):
+                break
+
+            url_path = ("org.opendaylight.controller:Category"
+                        "=ShardManager,name=shard-manager-{},type=Distributed"
+                        "{}Datastore".format(data_store.lower(), data_store))
+            odl_client = controller['client']
+            try:
+                data = odl_client.request('get', url_path).json()
+            except (exceptions.ConnectionError, exceptions.ReadTimeout,
+                    ValueError):
+                data = None
+
+            # grab the controller name from the first shard
+            try:
+                controller['name'] = data['value']['MemberName']
+            except (KeyError, TypeError):
+                controller['name'] = "{}:{}".format(
+                    controller['ip'], controller['port'])
+
+            # collect shards found in any controller; does not require
+            # all controllers to have the same shards
+            if data and 'value' in data and 'LocalShards' in data['value']:
+                for local_shard in data['value']['LocalShards']:
+                    match = "^.*?-shard-(.+?)-{}$".format(data_store.lower())
+                    m = re.search(match, local_shard)
+                    if m and m.group(1) not in excluded_shards:
+                        shards.add(m.group(1))
+
+            controller_len = max(controller_len, len(controller['name']))
+
+        if shards:
+            field_len = max(map(len, shards)) + 2
+        else:
+            field_len = max(field_len, 0)
+
+        # Ensure everything fits
+        if controller_len + 1 + (field_len + 1) * len(shards) > maxx:
+            extra = controller_len + 1 + (field_len + 1) * len(shards) - maxx
+            delta = int(math.ceil(float(extra) / (1 + len(shards))))
+            controller_len -= delta
+            field_len -= delta
+
+        # no shards found, use default
+        if not shards:
+            real_shards = ['default']
+        else:
+            real_shards = shards
+        stdscr.move(0, 2)
+        stdscr.clrtoeol()
+        for data_column, shard in enumerate(real_shards):
+            stdscr.addstr(1, controller_len + 1 + (field_len + 1) *
+                          data_column, shard.center(field_len),
+                          curses.color_pair(con.WHITE_ON_BLACK))
+        # display controller and shard headers
+        for row, controller in enumerate(controllers):
+            addr = "{}:{}".format(controller['ip'], controller['port'])
+            stdscr.addstr(row + 2, 0,
+                          addr.center(controller_len),
+                          curses.color_pair(con.WHITE_ON_BLACK))
+
+        stdscr.addstr(0, 0, 'Controller'.center(controller_len),
+                      curses.color_pair(con.WHITE_ON_BLACK))
+        stdscr.addstr(0, max(controller_len + 1, 10),
+                      'Shards/Status'.center(field_len),
+                      curses.color_pair(con.WHITE_ON_BLACK))
+        stdscr.refresh()
+
+        # display shard status
+        for data_column, shard_name in enumerate(real_shards):
+            key = max(key, stdscr.getch())
+            if key == ord('q') or key == ord('Q'):
+                break
+
+            if shard_name not in excluded_shards:
+                cluster_stat = get_cluster_roles(shard_name,
+                                                 controllers,
+                                                 data_store)
+                for row, controller in enumerate(controllers):
+                    status = size_and_color(cluster_stat, field_len,
+                                            controller["ip"])
+                    stdscr.addstr(row + 2, controller_len + 1 +
+                                  (field_len + 1) * data_column, status['txt'],
+                                  status['color'])
+            time.sleep(0.5)
+            stdscr.refresh()
+
+
+def run_monitor(args):
+
+    data_store = args.datastore
+    if data_store != 'Config' and data_store != 'Operational':
+        raise OdlMonitoringException('"Config" or "Operational" data store '
+                                     'not found')
+
+    cluster_file = args.config_file
+    if not os.path.isfile(cluster_file):
+        raise OdlClusterCfgException('Cluster config file does not exist:'
+                                     '{}'.format(cluster_file))
+
+    data = None
+    with open(cluster_file) as fh:
+        try:
+            data = json.load(fh)
+        except ValueError:
+            raise OdlMonitoringException(('Unable to decode cluster config '
+                                          'json file: '
+                                          '{}').format(cluster_file))
+
+    if 'cluster' in data:
+        for cluster_key in ('controllers', 'shards_to_exclude', 'user',
+                            'pass'):
+            if cluster_key not in data['cluster']:
+                raise OdlClusterCfgException('Invalid Cluster Config. '
+                                             'Missing required key: '
+                                             '{}'.format(cluster_key))
+    else:
+        raise OdlClusterCfgException('Invalid Cluster config format. The '
+                                     'key "cluster" is undefined')
+
+    # validate values
+    for setting in ('controllers', 'user', 'pass'):
+        if data['cluster'][setting] is None:
+            raise OdlClusterCfgException(
+                'Invalid null value for cluster '
+                'config setting: {}'.format(data['cluster'][setting]))
+
+    controllers = data["cluster"]["controllers"]
+    shards_to_exclude = data["cluster"]["shards_to_exclude"]
+    username = data["cluster"]["user"]
+    password = data["cluster"]["pass"]
+    with CursesWindow() as stdscr:
+        try:
+            cluster_monitor(stdscr, controllers, username, password,
+                            data_store, excluded_shards=shards_to_exclude)
+        except KeyboardInterrupt:
+            pass


### PR DESCRIPTION
This patch adds a tool to be able to monitor the OpenDaylight cluster
using a json config file created by a user/operator.  The tool is a
re-factor of a script used in OpenDaylight integration/test repo here:
https://github.com/opendaylight/integration-test/blob/master/tools/clustering/cluster-monitor/monitor.py

Changes from the original script include:
 - Improved usability with curses (Terminal window is no longer broken
   after quitting the tool)
 - Integration with a common ODL rest client (uses requests
   rather than pycurl)
 - Improved error detection and more accurate information displayed
   to user/operator
 - Installed as an executable in system path
 - Now meets pep8 requirements and is python3 compatible
 - Simplified logic and readability